### PR TITLE
Fix entropy starvation

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
     {
       "plan": "heroku-postgresql:hobby-dev",
       "options": {
-        "version": "10.3"
+        "version": "10"
       }
     }
   ],


### PR DESCRIPTION
Turns out that anytime we were doing anything crypto-related (e.g. signing), we were crawling to a halt because of Heroku running out of entropy and /dev/urandom blocking.  So now we just seed a PRNG with a strong seed.