### PR TITLE
Add `/api/fact` to production server

### DIFF
--- a/client-interface/src/main/java/java2ts/CodegenConfig.java
+++ b/client-interface/src/main/java/java2ts/CodegenConfig.java
@@ -39,23 +39,24 @@ public class CodegenConfig implements StaticCodegenConfig {
 	public TypeLiteral[] whatToCodegen() {
 		return new TypeLiteral[]{
 				TypeLiteral.create(Bookmark.class), Bookmark.LIST,
-				TypeLiteral.create(DraftRev.class),
 				TypeLiteral.create(DraftPost.class),
-				TypeLiteral.create(PublishResult.class),
+				TypeLiteral.create(DraftRev.class),
+				TypeLiteral.create(FollowJson.FollowAskReq.class),
+				TypeLiteral.create(FollowJson.FollowRes.class),
+				TypeLiteral.create(FollowJson.FollowTellReq.class),
+				TypeLiteral.create(GhBlob.class),
 				TypeLiteral.create(LoginApi.Req.class),
 				TypeLiteral.create(LoginApi.Res.class),
 				TypeLiteral.create(LoginCookie.class),
-				TypeLiteral.create(TakeReactionJson.UserState.class),
-				TypeLiteral.create(TakeReactionJson.TakeState.class),
+				TypeLiteral.create(PublishResult.class),
+				TypeLiteral.create(Search.FactResultList.class),
+				TypeLiteral.create(Search.VideoResult.class),
 				TypeLiteral.create(TakeReactionJson.ReactReq.class),
 				TypeLiteral.create(TakeReactionJson.ReactRes.class),
+				TypeLiteral.create(TakeReactionJson.TakeState.class),
+				TypeLiteral.create(TakeReactionJson.UserState.class),
 				TypeLiteral.create(TakeReactionJson.ViewReq.class),
-				TypeLiteral.create(TakeReactionJson.ViewRes.class),
-				TypeLiteral.create(FollowJson.FollowAskReq.class),
-				TypeLiteral.create(FollowJson.FollowTellReq.class),
-				TypeLiteral.create(FollowJson.FollowRes.class),
-				TypeLiteral.create(Search.VideoResult.class),
-				TypeLiteral.create(Search.FactResultList.class)
+				TypeLiteral.create(TakeReactionJson.ViewRes.class)
 		};
 	}
 

--- a/client-interface/src/main/java/java2ts/GhBlob.java
+++ b/client-interface/src/main/java/java2ts/GhBlob.java
@@ -1,0 +1,25 @@
+/*
+ * MyTake.org website and tooling.
+ * Copyright (C) 2020 MyTake.org, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact us at team@mytake.org
+ */
+package java2ts;
+
+@jsweet.lang.Interface
+public class GhBlob {
+	public String content;
+}

--- a/client-interface/src/main/java/java2ts/Routes.java
+++ b/client-interface/src/main/java/java2ts/Routes.java
@@ -30,6 +30,7 @@ public class Routes {
 	public static final String API_SEARCH = "/api/search";
 	public static final String API_BOOKMARKS = "/api/bookmarks";
 	public static final String API_LOGIN = "/api/login";
+	public static final String API_FACT = "/api/fact";
 
 	public static final String MODS = "/mods";
 	public static final String MODS_DRAFTS = "/mods/drafts/";

--- a/factset-tooling/README.md
+++ b/factset-tooling/README.md
@@ -112,6 +112,8 @@ mtdoFactSet {
 # Changelog
 
 ## [Unreleased]
+### Fixed
+* `index.json` now has correct blob sha1 (was missing blob header).
 
 ## [0.2.4] - 2020-09-25
 ### Fixed

--- a/factset-tooling/build.gradle
+++ b/factset-tooling/build.gradle
@@ -87,7 +87,7 @@ dependencies {
 	implementation "com.jsoniter:jsoniter:$VER_JSONITER"
 	implementation 'com.google.code.gson:gson:2.8.6'
 	implementation 'org.jsoup:jsoup:1.13.1'
-	implementation 'org.eclipse.jgit:org.eclipse.jgit:5.9.0.202009080501-r'
+	implementation "org.eclipse.jgit:org.eclipse.jgit:${VER_JGIT}"
 	implementation 'com.diffplug.durian:durian-core:1.2.0'
 	implementation 'com.diffplug.durian:durian-collect:1.2.0'
 	implementation 'com.diffplug.durian:durian-io:1.2.0'

--- a/factset-tooling/src/main/java/org/mytake/factset/GitJson.java
+++ b/factset-tooling/src/main/java/org/mytake/factset/GitJson.java
@@ -30,7 +30,6 @@ package org.mytake.factset;
 
 
 import com.diffplug.common.base.Preconditions;
-import com.diffplug.common.io.BaseEncoding;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -45,13 +44,13 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java2ts.FT;
+import org.eclipse.jgit.util.sha1.SHA1;
 
 public class GitJson {
 	public static final String COMMENT_OPEN_STR = "⌊";
@@ -270,9 +269,14 @@ public class GitJson {
 		return new FieldParser(jsonReader);
 	}
 
-	public static String sha1base16(byte[] content) throws NoSuchAlgorithmException {
-		MessageDigest digest = MessageDigest.getInstance("SHA-1");
-		byte[] hash = digest.digest(content);
-		return BaseEncoding.base16().encode(hash).toLowerCase(Locale.ROOT);
+	public static String blobSha(byte[] content) throws NoSuchAlgorithmException {
+		SHA1 sha = SHA1.newInstance();
+		// git blob header
+		sha.update("blob ".getBytes(StandardCharsets.UTF_8));
+		sha.update(Integer.toString(content.length).getBytes(StandardCharsets.UTF_8));
+		sha.update((byte) 0);
+		// then the content
+		sha.update(content);
+		return sha.toObjectId().getName();
 	}
 }

--- a/factset-tooling/src/main/java/org/mytake/factset/GitJson.java
+++ b/factset-tooling/src/main/java/org/mytake/factset/GitJson.java
@@ -73,6 +73,7 @@ public class GitJson {
 	 * - add ⌊⌋ pairs (mathematic floor) anywhere, they are treated as a comment and removed
 	 */
 	public static String recondense(String in, StringBuilder buffer) {
+		// if you change this, make sure to update FactApi.recondense in server!
 		Preconditions.checkArgument(!in.isEmpty());
 		Preconditions.checkArgument(in.charAt(0) != '\n');
 		Preconditions.checkArgument(in.charAt(0) != COMMENT_OPEN);

--- a/factset-tooling/src/main/java/org/mytake/factset/gradle/GrindLogic.java
+++ b/factset-tooling/src/main/java/org/mytake/factset/gradle/GrindLogic.java
@@ -179,7 +179,7 @@ public class GrindLogic {
 				FactLink link = new FactLink();
 				try (GitJson.FieldParser parser = GitJson.parse(content)) {
 					link.fact = parser.field("fact", FT.Fact.class);
-					link.hash = GitJson.sha1base16(content);
+					link.hash = GitJson.blobSha(content);
 				} catch (NoSuchAlgorithmException e) {
 					throw Errors.asRuntime(e);
 				}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,8 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.vfs.watch=true
 
+VER_JGIT=5.9.0.202009080501-r
+
 # should match client.gradle / jsweet.targetVersion
 # 6.2.0 requires Java 11
 VER_JSWEET_CORE=6.0.4

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -154,7 +154,8 @@ dependencies {
 	testImplementation "com.palantir.docker.compose:docker-compose-rule-core:$VER_PALANTIR_DOCKER_COMPOSE"		// https://github.com/palantir/docker-compose-rule
 	testImplementation "com.palantir.docker.compose:docker-compose-rule-junit4:$VER_PALANTIR_DOCKER_COMPOSE"	// https://github.com/palantir/docker-compose-rule
 
-	testImplementation "com.fizzed:rocker-compiler:${rockerVersion}"					// required for hotreload
+	testImplementation "com.fizzed:rocker-compiler:${rockerVersion}"	// required for hotreload
+	testImplementation "org.eclipse.jgit:org.eclipse.jgit:${VER_JGIT}"	// required for serving local repo
 
 	// dep for auth
 	implementation 'com.auth0:java-jwt:3.10.3'

--- a/server/src/main/java/common/Prod.java
+++ b/server/src/main/java/common/Prod.java
@@ -24,6 +24,7 @@ import controllers.About;
 import controllers.BookmarkApi;
 import controllers.DiscourseAuth;
 import controllers.Drafts;
+import controllers.FactApi;
 import controllers.FoundationAssets;
 import controllers.HomeFeed;
 import controllers.Profile;
@@ -66,6 +67,7 @@ public class Prod extends Jooby {
 		});
 		use(new InitialData.Module());
 		controllers(this);
+		use(new FactApi());
 	}
 
 	static void flywayMigrate(Registry registry) {

--- a/server/src/main/java/controllers/FactApi.java
+++ b/server/src/main/java/controllers/FactApi.java
@@ -1,0 +1,112 @@
+/*
+ * MyTake.org website and tooling.
+ * Copyright (C) 2020 MyTake.org, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact us at team@mytake.org
+ */
+package controllers;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.jsoniter.JsonIterator;
+import com.typesafe.config.Config;
+import common.RedirectException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java2ts.GhBlob;
+import java2ts.Routes;
+import okhttp3.OkHttpClient;
+import org.jooby.Env;
+import org.jooby.Jooby;
+import org.jooby.Results;
+
+public class FactApi implements Jooby.Module {
+	public static ImmutableList<String> REPOS = ImmutableList.of("us-founding-documents", "us-presidential-debates");
+
+	@Override
+	public void configure(Env env, Config conf, Binder binder) throws Throwable {
+		env.router().get(Routes.API_FACT + "/:repoIdx/:sha", req -> {
+			int repoIdx = req.param("repoIdx").intValue();
+			String sha = req.param("sha").value();
+			if (repoIdx < 0 || repoIdx >= REPOS.size()) {
+				throw RedirectException.notFoundError();
+			}
+			byte[] contentGitFriendly = repoSha(REPOS.get(repoIdx), sha);
+			// recondense the json
+			String content = recondense(new String(contentGitFriendly, StandardCharsets.UTF_8));
+			return Results.json(content).header("Cache-Control",
+					"max-age=31536000", // one year https://stackoverflow.com/a/25201898/1153071
+					"public", // any cache may store the response
+					"no-transform", // don't muck with it at all
+					"immutable" // it will never change at all for sure
+			);
+		});
+	}
+
+	protected byte[] repoSha(String repo, String sha) throws IOException {
+		// ask github
+		OkHttpClient client = new OkHttpClient();
+		okhttp3.Response res = client.newCall(new okhttp3.Request.Builder()
+				.url("https://api.github.com/repos/mytakedotorg/" + repo + "/git/blobs/" + sha)
+				.build()).execute();
+		// unpack github's wrapper
+		GhBlob blob = JsonIterator.deserialize(res.body().bytes(), GhBlob.class);
+		return Base64.getMimeDecoder().decode(blob.content);
+	}
+
+	// From GitJson.recondense
+	private static final char COMMENT_OPEN = '⌊';
+	private static final char COMMENT_CLOSE = '⌋';
+
+	static String recondense(String in) {
+		StringBuilder buffer = new StringBuilder(in.length());
+		int start = 0;
+		int next;
+		while ((next = nextParsePaint(in, start)) != 0) {
+			if (next > 0) {
+				// was '\n'
+				buffer.append(in, start, next);
+				start = next + 1; // skip the \n
+			} else {
+				// was ⌊, ignore everything up to the next ⌋
+				buffer.append(in, start, -next);
+				int close = in.indexOf(COMMENT_CLOSE, -next + 1);
+				if (close == -1) {
+					return buffer.toString();
+				} else {
+					start = close + 1;
+				}
+			}
+		}
+		if (start < in.length()) {
+			buffer.append(in, start, in.length());
+		}
+		return buffer.toString();
+	}
+
+	private static int nextParsePaint(String in, int startFrom) {
+		for (int i = startFrom; i < in.length(); ++i) {
+			char c = in.charAt(i);
+			if (c == '\n') {
+				return i;
+			} else if (c == COMMENT_OPEN) {
+				return -i;
+			}
+		}
+		return 0; // signifies end of string
+	}
+}

--- a/server/src/test/java/common/Dev.java
+++ b/server/src/test/java/common/Dev.java
@@ -24,6 +24,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.typesafe.config.Config;
+import controllers.FactApiDev;
 import javax.mail.Address;
 import javax.mail.Message.RecipientType;
 import javax.mail.internet.MimeMessage;
@@ -58,6 +59,7 @@ public class Dev extends DevNoDB {
 		use(postgresModule);
 		Prod.commonDb(this);
 		Prod.controllers(this);
+		use(new FactApiDev());
 	}
 
 	static class JooqDebugRenderer implements Jooby.Module {

--- a/server/src/test/java/controllers/FactApiDev.java
+++ b/server/src/test/java/controllers/FactApiDev.java
@@ -1,0 +1,63 @@
+/*
+ * MyTake.org website and tooling.
+ * Copyright (C) 2020 MyTake.org, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact us at team@mytake.org
+ */
+package controllers;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+/**
+ * If you checkout a fact repository as a peer to this, and add a "mtdo-" prefix to the folder name,
+ * then this class will use that local git repository to serve the facts, rather than GitHub.
+ */
+public class FactApiDev extends FactApi {
+	private Set<String> localRepos = new HashSet<>();
+
+	public FactApiDev() {
+		for (String repo : REPOS) {
+			if (localRepo(repo).exists()) {
+				localRepos.add(repo);
+			}
+		}
+	}
+
+	private File localRepo(String repo) {
+		return new File("../../mtdo-" + repo + "/.git");
+	}
+
+	@Override
+	protected byte[] repoSha(String repo, String sha) throws IOException {
+		if (localRepos.contains(repo)) {
+			try (Repository repository = new FileRepositoryBuilder().setGitDir(localRepo(repo)).build()) {
+				return repository.open(ObjectId.fromString(sha), Constants.OBJ_BLOB).getBytes();
+			} catch (IOException e) {
+				System.err.println("Maybe pull latest commits for " + localRepo(repo).getAbsolutePath());
+				throw e;
+			}
+		} else {
+			return super.repoSha(repo, sha);
+		}
+	}
+}

--- a/server/src/test/java/controllers/FactApiTest.java
+++ b/server/src/test/java/controllers/FactApiTest.java
@@ -33,6 +33,11 @@ public class FactApiTest {
 		testFactModule(new FactApi());
 	}
 
+	@Test
+	public void dev() throws Exception {
+		testFactModule(new FactApiDev());
+	}
+
 	private void testFactModule(Jooby.Module factApiModule) throws Exception {
 		try (AutoCloseable server = startServer(factApiModule)) {
 			byte[] actualBytes = RestAssured.given().get("/api/fact/1/c2a9d475e448866c48a1f7c0d5f98c6fc2bfe6a3").then()

--- a/server/src/test/java/controllers/FactApiTest.java
+++ b/server/src/test/java/controllers/FactApiTest.java
@@ -1,0 +1,53 @@
+/*
+ * MyTake.org website and tooling.
+ * Copyright (C) 2020 MyTake.org, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact us at team@mytake.org
+ */
+package controllers;
+
+import common.JoobyDevRule;
+import io.restassured.RestAssured;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.jooby.Jooby;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class FactApiTest {
+	static class App extends Jooby {
+		{
+			use(new FactApi());
+		}
+	}
+
+	@ClassRule
+	public static JoobyDevRule app = new JoobyDevRule(new App());
+
+	@Test
+	public void factTest() throws IOException {
+		byte[] actualBytes = RestAssured.given().get("/api/fact/1/c2a9d475e448866c48a1f7c0d5f98c6fc2bfe6a3").then()
+				.contentType("application/json")
+				.extract().body().asByteArray();
+		String actual = new String(actualBytes, StandardCharsets.UTF_8);
+		byte[] expectedBytes = Files.readAllBytes(Paths.get("../factset-tooling/src/test/resources/org/mytake/factset/gradle/kennedy-nixon-1-of-4.json"));
+		String expected = new String(expectedBytes, StandardCharsets.UTF_8);
+		Assert.assertEquals(FactApi.recondense(expected), actual);
+	}
+}

--- a/server/src/test/java/controllers/FactApiTest.java
+++ b/server/src/test/java/controllers/FactApiTest.java
@@ -19,35 +19,38 @@
  */
 package controllers;
 
-import common.JoobyDevRule;
 import io.restassured.RestAssured;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.jooby.Jooby;
 import org.junit.Assert;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 public class FactApiTest {
-	static class App extends Jooby {
-		{
-			use(new FactApi());
+	@Test
+	public void prod() throws Exception {
+		testFactModule(new FactApi());
+	}
+
+	private void testFactModule(Jooby.Module factApiModule) throws Exception {
+		try (AutoCloseable server = startServer(factApiModule)) {
+			byte[] actualBytes = RestAssured.given().get("/api/fact/1/c2a9d475e448866c48a1f7c0d5f98c6fc2bfe6a3").then()
+					.contentType("application/json")
+					.extract().body().asByteArray();
+			String actual = new String(actualBytes, StandardCharsets.UTF_8);
+			byte[] expectedBytes = Files.readAllBytes(Paths.get("../factset-tooling/src/test/resources/org/mytake/factset/gradle/kennedy-nixon-1-of-4.json"));
+			String expected = new String(expectedBytes, StandardCharsets.UTF_8);
+			Assert.assertEquals(FactApi.recondense(expected), actual);
 		}
 	}
 
-	@ClassRule
-	public static JoobyDevRule app = new JoobyDevRule(new App());
-
-	@Test
-	public void factTest() throws IOException {
-		byte[] actualBytes = RestAssured.given().get("/api/fact/1/c2a9d475e448866c48a1f7c0d5f98c6fc2bfe6a3").then()
-				.contentType("application/json")
-				.extract().body().asByteArray();
-		String actual = new String(actualBytes, StandardCharsets.UTF_8);
-		byte[] expectedBytes = Files.readAllBytes(Paths.get("../factset-tooling/src/test/resources/org/mytake/factset/gradle/kennedy-nixon-1-of-4.json"));
-		String expected = new String(expectedBytes, StandardCharsets.UTF_8);
-		Assert.assertEquals(FactApi.recondense(expected), actual);
+	private AutoCloseable startServer(Jooby.Module factApiModule) {
+		Jooby jooby = new Jooby();
+		jooby.use(factApiModule);
+		jooby.start("server.join=false");
+		return () -> {
+			jooby.stop();
+		};
 	}
 }


### PR DESCRIPTION
This PR adds the server side of grabbing fact data - it doesn't alter the frontend or database. By merging this and promoting to production, we can build tooling that counts on `mytake.org/api/fact/BLAH` being alive.