### PR TITLE
Instructions for frontend devs to proxy against the production server

### DIFF
--- a/DEV_QUICKSTART.md
+++ b/DEV_QUICKSTART.md
@@ -1,20 +1,22 @@
 # Dev quickstart
 
-You will need these installed on your system:
+You will need [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating) and Java 8+ installed on your system. If you want to run the full application, you will also need [Docker](https://docs.docker.com/get-docker/).
 
-- Java 8+
-- Docker
-- nvm (only if working on frontend)
+## Frontend only
 
-When you run `./gradlew runDev`, you will get a server running at `localhost:8080` with hot reload for templates.  If you then `cd` into the `client` directory, you can run:
+First, run `./gradlew :client:assemble`. This one-time step does code-generation into the `java2ts` folder. After that, `cd` into the `client` directory, and run
 
 ```
-nvm use   // get correct version of node & npm
-npm ci    // get dependencies
-npm start // start proxy server
+nvm use
+npm ci
+npm run proxyProd
 ```
 
-and you will have a browsersync proxy running at `localhost:3000` with hot reload for the react components and sass styles.
+and you will have dev environment which is proxying againg https://mytake.org, which is always deployed against the `prod` branch. Likewise, you can also run `npm run proxyStaging`, which proxies against https://mtdo-naked-staging.herokuapp.com, which is always deployed against the `staging` branch (which is where we accept PRs).
+
+## Full stack
+
+If you run `./gradlew runDev`, you will get a server running at `localhost:8080` with hot reload for server templates. You can then use the frontend instructions above with `npm run proxyDev` to get a local frontend environment.
 
 If you bump into any problems, we have listed [common errors and their solutions](#common-errors-and-their-solutions) below.
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -16,6 +16,7 @@ spotless {
 	}
 	format 'js', {
 		target 'gulpfile.js'
+		toggleOffOn()
 		prettier(VER_PRETTIER)
 	}
 }

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -40,10 +40,12 @@ const STYLES = "styles";
 const SCRIPTS = "scripts";
 const PERMANENT = "permanent";
 
+// spotless:off
 setupPipeline(DEV);
 setupPipeline(PROD);
 gulp.task("proxyStaging", proxyTask(DEV, "https://mtdo-naked-staging.herokuapp.com"));
 gulp.task("proxyProd", proxyTask(DEV, "https://mytake.org"));
+// spotless:on
 
 function setupPipeline(mode) {
   const styles = STYLES + mode;

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -64,7 +64,7 @@ function setupPipeline(mode) {
         .pipe(gulp.dest(config.distProd));
     });
   } else {
-    gulp.task("proxy" + mode, proxyTask(mode));
+    gulp.task("proxy" + mode, proxyTask(mode, "localhost:8080"));
   }
 }
 
@@ -204,12 +204,12 @@ function scriptsTask(mode, type) {
   };
 }
 
-function proxyTask(mode) {
+function proxyTask(mode, hostToProxy) {
   if (mode !== DEV) throw "proxyCfg is a dev-only task";
   return () => {
     const bundler = webpack(webpackCfg(mode));
     browserSync.init({
-      proxy: "localhost:8080",
+      proxy: hostToProxy,
       middleware: [
         webpackDevMiddleware(bundler, {
           publicPath: "/assets-dev/" + SCRIPTS,

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -42,6 +42,8 @@ const PERMANENT = "permanent";
 
 setupPipeline(DEV);
 setupPipeline(PROD);
+gulp.task("proxyStaging", proxyTask(DEV, "https://mtdo-naked-staging.herokuapp.com"));
+gulp.task("proxyProd", proxyTask(DEV, "https://mytake.org"));
 
 function setupPipeline(mode) {
   const styles = STYLES + mode;

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,9 @@
     "deploy": "npx gulp buildProd",
     "test": "npx jest",
     "test_ci": "npx jest --env=jsdom --maxWorkers=2 --ci --reporters=jest-junit",
-    "updateSnapshot": "npx jest --updateSnapshot"
+    "updateSnapshot": "npx jest --updateSnapshot",
+    "proxyStaging": "npx gulp proxyStaging",
+    "proxyProd": "npx gulp proxyProd"
   },
   "author": "MyTake.org, Inc.",
   "license": "AGPL-3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -9,14 +9,14 @@
     "url": "https://github.com/mytakedotorg/mtdo.git"
   },
   "scripts": {
-    "start": "npx gulp proxyDev",
     "clean": "npx gulp clean",
     "deploy": "npx gulp buildProd",
     "test": "npx jest",
     "test_ci": "npx jest --env=jsdom --maxWorkers=2 --ci --reporters=jest-junit",
     "updateSnapshot": "npx jest --updateSnapshot",
     "proxyStaging": "npx gulp proxyStaging",
-    "proxyProd": "npx gulp proxyProd"
+    "proxyProd": "npx gulp proxyProd",
+    "proxyDev": "npx gulp proxyDev"
   },
   "author": "MyTake.org, Inc.",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Implements #282. This lets frontend devs skip docker and the whole mess of running the server on their box.

The problem is that the tried-and-true `proxyDev` relies on the dev environment, which has slightly different html.  For example, here are the style/script tags in the `prod` and `staging` environments:

``` (
  (in the head)
<link rel="stylesheet" href="/assets/styles/main-9db944593f.css">
<link rel="stylesheet" href="/assets/styles/vis-36b0e089e7.css">
<link rel="stylesheet" href="/assets/styles/rc-slider-70f11d2e42.css">
  (bottom of the body)
<script type="text/javascript" src="https://unpkg.com/react@16.13.1/umd/react.production.min.js" integrity="sha384-Q5wFTPC/kyhbXJt5GLrIeka2uDOSTG7m1zpW91iMO1DJb7+vOwu2lgZC30d4uQmU" crossorigin="anonymous"></script>
<script type="text/javascript" src="https://unpkg.com/react-dom@16.13.1/umd/react-dom.production.min.js" integrity="sha384-T6Etav7ShYqIZe+prlqxX/h04T1Iu9ynDpcgx0iBgcl5u+AVlStV2kv3mMxfnV1C" crossorigin="anonymous"></script>
<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.min.js" integrity="sha384-2SbSbzJpoRtEf9BFT5KZAulTQs1JBK0XiQr38Mh0w8+wH0Ubuam+p5csoi5zCV7T" crossorigin="anonymous"></script>
<script type="text/javascript" src="https://unpkg.com/d3@5.16.0/dist/d3.min.js" integrity="sha384-M06Cb6r/Yrkprjr7ngOrJlzgekrkkdmGZDES/SUnkUpUol0/qjsaQWQfLzq0mcfg" crossorigin="anonymous"></script>
<script type="text/javascript" src="/assets/scripts/app-4793565d7b.bundle.js"></script>
```

versus what you get in the local dev

```
<link rel="stylesheet" href="/assets-dev/styles/main.css">
<link rel="stylesheet" href="/assets-dev/styles/vis.css">
<link rel="stylesheet" href="/assets-dev/styles/rc-slider.css">
...
<script type="text/javascript" src="https://unpkg.com/react@16.13.1/umd/react.development.js" integrity="sha384-U5suA1hvaY3jdSj/eys1iFOLEhVOrzFChmEU4xdxiMixWT3xOdKJB5nNd1OF9xim" crossorigin="anonymous"></script>
<script type="text/javascript" src="https://unpkg.com/react-dom@16.13.1/umd/react-dom.development.js" integrity="sha384-kaOkZyb5Zt3xjd+db4haVYVQCb1G7SF1nBLglYfcovj2yYb58gL0ntVd/oCqN1CE" crossorigin="anonymous"></script>
<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.min.js" integrity="sha384-2SbSbzJpoRtEf9BFT5KZAulTQs1JBK0XiQr38Mh0w8+wH0Ubuam+p5csoi5zCV7T" crossorigin="anonymous"></script>
<script type="text/javascript" src="https://unpkg.com/d3@5.16.0/dist/d3.js" integrity="sha384-qbNa7U27VV0Cghe/43y8zEMkmA5M4VxV6MI0k0vdVJKTrBoT2SnBqwccpD0vX+Is" crossorigin="anonymous"></script>
<script type="text/javascript" src="/assets-dev/scripts/app.bundle.js"></script>
```

And these differences are driven from [`assets.conf`](https://github.com/mytakedotorg/mtdo/blob/staging/server/src/main/resources/assets.conf) vs [`assets.dev.conf`](https://github.com/mytakedotorg/mtdo/blob/staging/server/src/main/resources/assets.dev.conf).

## Action needed

This PR will not work unless we figure out how to get the proxy server to at least "unhash" our own css/sass, and ideally it would also let us use the dev versions of react, etc. This is as far as I plan on taking this for now, help wanted.